### PR TITLE
クエリ文字列を指定して検索するAPIを追加で実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# 第8回課題
+## 概要
+-テーブルからレコードを全件取得するAPIとクエリ文字列を指定して検索するAPIも実装しました。
+
+## データベース概要
+- データベース名: music_database
+- テーブル数: 1
+- テーブル名: music
+
+   ![スクリーンショット (46)](https://github.com/kttsu/learning_task_8/assets/150462533/76643f61-db2f-4757-a945-c233a7f8d111)
+
+
+## 動作確認
+1. テーブルからレコードを全件取得
+
+   ![スクリーンショット (35)](https://github.com/kttsu/learning_task_8/assets/150462533/d0cfba49-07b2-4aea-a644-f2feb07a8c82)
+
+2. クエリ文字列を指定してレコードを取得
+  - startsWithで値 K を指定した場合
+
+    ![スクリーンショット (36)](https://github.com/kttsu/learning_task_8/assets/150462533/eb281d19-16d5-43af-b946-fcb3723cd980)
+
+ 
+  
+  - endsWithで値 O を指定した場合
+
+    ![スクリーンショット (47)](https://github.com/kttsu/learning_task_8/assets/150462533/0ffc73c7-9be0-4efc-a64c-10c47c8982bc)
+
+
+  - containsで値 I を指定した場合
+
+    ![スクリーンショット (48)](https://github.com/kttsu/learning_task_8/assets/150462533/13bc6ed1-2f78-4cbb-a61a-c5238f99e088)
+
+
+3.該当しない値を入力した場合
+　- containsで該当しない値 G を入力した場合 []　が返却される
+
+![スクリーンショット (49)](https://github.com/kttsu/learning_task_8/assets/150462533/2d518bb7-512e-4cdc-ac53-7ae62a7c5e74)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 
 
 3.該当しない値を入力した場合
-　- containsで該当しない値 G を入力した場合 []　が返却される
+ - contains=のように文字を指定しない場合
+   ![スクリーンショット (50)](https://github.com/kttsu/learning_task_8/assets/150462533/c270651b-234b-4951-b3a4-217605330aff)
+
+ - containsで該当しない値 G を入力した場合 []　が返却される
 
 ![スクリーンショット (49)](https://github.com/kttsu/learning_task_8/assets/150462533/2d518bb7-512e-4cdc-ac53-7ae62a7c5e74)

--- a/src/main/java/com/example/Music/MusicController.java
+++ b/src/main/java/com/example/Music/MusicController.java
@@ -14,7 +14,10 @@ public class MusicController {
         this.musicMapper = musicMapper;
     }
     @GetMapping("/music")
-    public List<Music> findByMusic(@RequestParam String startsWith) {
-        return musicMapper.findByMusicStartingWith(startsWith);
+    public List<Music> findByMusic(MusicSearchRequest request) {
+        System.out.println(request.getStartsWith());
+        System.out.println(request.getEndsWith());
+        System.out.println(request.getContains());
+        return musicMapper.findByMusicStartingWith(request.getStartsWith(),request.getEndsWith(),request.getContains());
     }
 }

--- a/src/main/java/com/example/Music/MusicController.java
+++ b/src/main/java/com/example/Music/MusicController.java
@@ -15,9 +15,6 @@ public class MusicController {
     }
     @GetMapping("/music")
     public List<Music> findByMusic(MusicSearchRequest request) {
-        System.out.println(request.getStartsWith());
-        System.out.println(request.getEndsWith());
-        System.out.println(request.getContains());
         return musicMapper.findByMusicStartingWith(request.getStartsWith(),request.getEndsWith(),request.getContains());
     }
 }

--- a/src/main/java/com/example/Music/MusicMapper.java
+++ b/src/main/java/com/example/Music/MusicMapper.java
@@ -9,8 +9,8 @@ import java.util.List;
 public interface MusicMapper {
     @Select("SELECT * FROM music")
     List<Music>findAll();
-    @Select("SELECT * FROM music WHERE name LIKE CONCAT(#{prefix}, '%')")
-    List<Music> findByMusicStartingWith(String prefix);
+    @Select("SELECT * FROM music WHERE name LIKE CONCAT(#{prefix}, '%') AND name LIKE CONCAT('%',#{suffix}) AND name LIKE CONCAT('%',#{contains}, '%')")
+    List<Music> findByMusicStartingWith(String prefix, String suffix, String contains);
 
 
 }

--- a/src/main/java/com/example/Music/MusicSearchRequest.java
+++ b/src/main/java/com/example/Music/MusicSearchRequest.java
@@ -1,0 +1,37 @@
+package com.example.Music;
+
+public class MusicSearchRequest {
+    private String startsWith;
+    private String endsWith;
+    private String contains;
+
+    public MusicSearchRequest(String startsWith, String endsWith, String contains) {
+        this.startsWith = startsWith;
+        this.endsWith = endsWith;
+        this.contains = contains;
+    }
+
+    public String getStartsWith() {
+        return startsWith == null ? "" : startsWith;
+    }
+
+    public void setStartsWith(String startsWith) {
+        this.startsWith = startsWith;
+    }
+
+    public String getEndsWith() {
+        return endsWith == null ? "" : endsWith;
+    }
+
+    public void setEndsWith(String endsWith) {
+        this.endsWith = endsWith;
+    }
+
+    public String getContains() {
+        return contains == null ? "" : contains;
+    }
+
+    public void setContains(String contains) {
+        this.contains = contains;
+    }
+}


### PR DESCRIPTION
## 概要
-クエリ文字列を指定して検索するAPIを追加で実装しました。

## 動作確認
1. テーブルからレコードを全件取得

   ![スクリーンショット (35)](https://github.com/kttsu/learning_task_8/assets/150462533/d0cfba49-07b2-4aea-a644-f2feb07a8c82)

2. クエリ文字列を指定してレコードを取得
  - startsWithで値 K を指定した場合

    ![スクリーンショット (36)](https://github.com/kttsu/learning_task_8/assets/150462533/eb281d19-16d5-43af-b946-fcb3723cd980)

 
  
  - endsWithで値 O を指定した場合

    ![スクリーンショット (47)](https://github.com/kttsu/learning_task_8/assets/150462533/0ffc73c7-9be0-4efc-a64c-10c47c8982bc)


  - containsで値 I を指定した場合

    ![スクリーンショット (48)](https://github.com/kttsu/learning_task_8/assets/150462533/13bc6ed1-2f78-4cbb-a61a-c5238f99e088)


3.該当しない値を入力した場合
 - contains= のように文字を指定しない場合
 ![スクリーンショット (50)](https://github.com/kttsu/learning_task_8/assets/150462533/c270651b-234b-4951-b3a4-217605330aff)

 - containsで該当しない値 G を入力した場合 []　が返却される

![スクリーンショット (49)](https://github.com/kttsu/learning_task_8/assets/150462533/2d518bb7-512e-4cdc-ac53-7ae62a7c5e74)

